### PR TITLE
Codecov github action

### DIFF
--- a/.github/workflows/example_workflow_for_codecov.yaml
+++ b/.github/workflows/example_workflow_for_codecov.yaml
@@ -1,0 +1,24 @@
+on: ["push", "pull_request"]
+name: Example workflow for Codecov
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: php-actions/composer@v5
+      - uses: php-actions/phpunit@v3
+        with:
+          configuration: phpunit.xml.dist
+          php_extensions: xdebug
+          bootstrap: vendor/autoload.php
+          args: --coverage-clover=clover.xml -vvv
+        env:
+          XDEBUG_MODE: coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./clover.xml
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # php-hetu
 
+[![codecov](https://codecov.io/gh/SPLCompanyOy/php-hetu/branch/master/graph/badge.svg?token=5TWOBQSRJD)](https://codecov.io/gh/SPLCompanyOy/php-hetu)
+
 Finnish Social Security number validator.
 
 This simple class validates social security numbers and provides methods for checking birthdate, age and gender based on the 'hetu'.

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
     },
     "autoload": {
         "classmap": ["src/"]
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="./tests/bootstrap.php"
         >
     <testsuites>
@@ -17,9 +16,9 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
# Summary

This PR introduces codecov.io as a tool to track codebase test coverage.

# Description

In the #1 I tried setting up https://coveralls.io/ as a PHP project coverage tracking service. After a number of tries, I changed focus and tried how the process would be setup with https://about.codecov.io/ with success.