### PR TITLE
SSN 2027 Remove personal information parsing from Hetu

### DIFF
--- a/src/Hetu.php
+++ b/src/Hetu.php
@@ -13,10 +13,6 @@ use Devsmo\Exceptions\InvalidYearException;
 
 class Hetu {
 
-
-    public const FEMALE = 'female';
-    public const MALE = 'male';
-
 	public string $hetu;
 	public $parts = null;
 
@@ -125,18 +121,6 @@ class Hetu {
 			case '-': return 1900;
 			case 'A': return 2000;
 			default: return null;
-		}
-	}
-
-	/**
-	 * getGender
-	 * Get the sex based on the hetu
-	 * @return String, 'male' or 'female'
-	 */
-	public function getGender() {
-		switch ( $this->parts->id & 1 ) {
-			case 0: return self::FEMALE;
-			case 1: return self::MALE;
 		}
 	}
 }

--- a/tests/HetuTest.php
+++ b/tests/HetuTest.php
@@ -11,15 +11,15 @@ class HetuTest extends TestCase
 	{
 		return array(
 			// Valid sets (all values are valid)
-			array('211097-9476', Hetu::MALE, '1997-10-21', 20),
-			array('210202A992N', Hetu::FEMALE, '2002-02-21', 15),
+			array('211097-9476', '1997-10-21', 20),
+			array('210202A992N', '2002-02-21', 15),
 		);
 	}
 	
 	/**
 	 * @dataProvider validTestSet
 	 */
-	public function testValidity($hetu, $gender, $birthday, $age)
+	public function testValidity($hetu, $birthday, $age)
 	{
 		$instance = Hetu::create($hetu);
 		$this->assertNotNull($instance);
@@ -28,22 +28,7 @@ class HetuTest extends TestCase
 	/**
 	 * @dataProvider validTestSet
 	 */
-	public function testGender($hetu, $gender, $birthday, $age)
-	{
-		$instance = Hetu::create($hetu);
-		$this->assertEquals($gender, $instance->getGender());
-	}
-
-	/**
-	 * @dataProvider validTestSet
-
-
-
-
-
-
-	 */
-	public function testBirthday($hetu, $gender, $birthday, $age)
+	public function testBirthday($hetu, $birthday, $age)
 	{
 		$instance = Hetu::create($hetu);
 		$this->assertEquals($birthday, $instance->getDateStr());
@@ -52,7 +37,7 @@ class HetuTest extends TestCase
 	/**
 	 * @dataProvider validTestSet
 	 */
-	public function testAge($hetu, $gender, $birthday, $age)
+	public function testAge($hetu, $birthday, $age)
 	{
 		$instance = Hetu::create($hetu);
 		$this->assertEquals($age, $instance->getAge(Carbon::parse('2018-02-02')));


### PR DESCRIPTION
From 2027 onward a new form of SSN is to be used in Finland.
The new SSN will not contain any information describing
the person.

https://vm.fi/henkilotunnuksen-uudistamisen-hanke